### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # permissions and limitations under the License.
 # See the AUTHORS file for names of contributors.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 cmake_policy(SET CMP0079 NEW)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")


### PR DESCRIPTION
Using cmake version lower than 3.14.0 will suffer cmake error because cmake policy "CMP0079" is not supported in those versions.
I tried cmake version from 3.10.3 to 3.14.3, and 3.14.3 is ok.
`(python3.6) liusiyang@gpu-lambda:~/TurboTransformers$ sh tools/build_and_run_unittests.sh $PWD -DWITH_GPU=OFF
+ [ 2 -lt 2 ]
+ SRC_ROOT=/home/liusiyang/TurboTransformers
+ WITH_GPU=-DWITH_GPU=OFF
+ BUILD_PATH=/tmp/build
+ bash /home/liusiyang/TurboTransformers/tools/compile.sh /home/liusiyang/TurboTransformers -DWITH_GPU=OFF /tmp/build
+ SRC_ROOT=/home/liusiyang/TurboTransformers
+ WITH_GPU=-DWITH_GPU=OFF
+ BUILD_PATH=/tmp/build
+ '[' 3 == 3 ']'
+ BUILD_PATH=/tmp/build
+ rm -rf /tmp/build
+ mkdir -p /tmp/build
+ cd /tmp/build
+ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release /home/liusiyang/TurboTransformers -DWITH_GPU=OFF
CMake Error at CMakeLists.txt:15 (cmake_policy):
  Policy "CMP0079" is not known to this version of CMake.`