### PR TITLE
Jiaruifang/profiler kernels

### DIFF
--- a/turbo_transformers/core/CMakeLists.txt
+++ b/turbo_transformers/core/CMakeLists.txt
@@ -57,7 +57,7 @@ add_executable(tt_core_test
         enforce_test.cpp
         device_context_test.cpp
         tensor_test.cpp
-  allocator_test.cpp
+        allocator_test.cpp
         fp16_test.cpp)
 target_link_libraries(tt_core_test catch2_test_main tt_core)
 add_test(NAME tt_core_test  COMMAND tt_core_test)

--- a/turbo_transformers/core/allocator.cpp
+++ b/turbo_transformers/core/allocator.cpp
@@ -55,7 +55,7 @@ void *allocate_impl(size_t size, DLDeviceType dev) {
   if (kDLCPU == dev) {
     return align_alloc(size);
   } else if (kDLGPU == dev) {
-#ifdef TT_WITH_GPU
+#ifdef TT_WITH_CUDA
     auto addr = cuda_alloc(size);
     return addr;
 #endif
@@ -69,7 +69,7 @@ void free_impl(void *memory_addr, DLDeviceType dev) {
   if (kDLCPU == dev) {
     free(memory_addr);
   } else if (kDLGPU == dev) {
-#ifdef TT_WITH_GPU
+#ifdef TT_WITH_CUDA
     cuda_free(memory_addr);
 #endif
   } else {

--- a/turbo_transformers/core/allocator_test.cpp
+++ b/turbo_transformers/core/allocator_test.cpp
@@ -40,17 +40,17 @@ TEST_CASE("cuda_allocator_cub", "Test the cubcaching allocator") {
     allocator.free(addr_list[i], "cub", kDLGPU);
   }
 }
-#endif
 
 TEST_CASE("cuda_allocator_bestfit", "Test the bestfit allocator") {
   Allocator &allocator = Allocator::GetInstance();
   std::vector<size_t> size_list{100, 100, 1000, 256, 200};
   std::vector<void *> addr_list(4);
   for (size_t i = 0; i < size_list.size(); ++i) {
-    addr_list[i] = allocator.allocate(size_list[i], "bestfit", kDLCPU);
-    allocator.free(addr_list[i], "bestfit", kDLCPU);
+    addr_list[i] = allocator.allocate(size_list[i], "bestfit", kDLGPU);
+    allocator.free(addr_list[i], "bestfit", kDLGPU);
   }
 }
+#endif
 
 }  // namespace core
 }  // namespace turbo_transformers

--- a/turbo_transformers/core/profiler.cpp
+++ b/turbo_transformers/core/profiler.cpp
@@ -31,6 +31,11 @@ namespace core {
 #ifdef WITH_PERFTOOLS
 static bool gProfileEnabled = false;
 
+static bool comp(std::pair<std::string, double> a,
+                 std::pair<std::string, double> b) {
+  return a.second < b.second;
+}
+
 struct Profiler::ProfilerImpl {
   void start_profile(const std::string& ctx_name, DLDeviceType dev_type) {
     if (kDLGPU == dev_type) {
@@ -80,8 +85,16 @@ struct Profiler::ProfilerImpl {
   }
   void print_results() const {
     std::cerr << std::endl << profile_name_ << " Time line: " << std::endl;
+    std::vector<std::pair<std::string, double>> elems(timer_map_.begin(),
+                                                      timer_map_.end());
+    std::sort(elems.begin(), elems.end(), comp);
+    float total_elapsed = 0.;
     for (auto it = timer_map_.begin(); it != timer_map_.end(); ++it) {
-      std::cerr << it->first << " , " << it->second << std::endl;
+      total_elapsed += it->second;
+    }
+    for (auto it = elems.begin(); it != elems.end(); ++it) {
+      std::cerr << it->first << " , " << it->second << ", "
+                << it->second / total_elapsed * 100 << " % " << std::endl;
     }
   }
   void clear() {

--- a/turbo_transformers/core/tensor_copy.h
+++ b/turbo_transformers/core/tensor_copy.h
@@ -14,8 +14,13 @@
 #pragma once
 
 #include <vector>
+
 #include "turbo_transformers/core/memory.h"
 #include "turbo_transformers/core/tensor.h"
+
+#ifdef WITH_PERFTOOLS
+#include "turbo_transformers/core/profiler.h"
+#endif
 
 namespace turbo_transformers {
 namespace core {
@@ -38,12 +43,20 @@ static inline void Copy(const core::Tensor &src, std::vector<T> &dst) {
   core::Memcpy(dst.data(), src.data<T>(), sizeof(T) * src.numel(), flag);
 }
 template <typename T>
-static inline void Copy(const core::Tensor &src, core::Tensor &dst) {
+static inline void Copy(const core::Tensor &src, core::Tensor &dst,
+                        const std::string name = "Copy") {
+#ifdef WITH_PERFTOOLS
+  auto &profile_ctx = core::Profiler::GetInstance();
+  profile_ctx.start_profile(name, src.device_type());
+#endif
   TT_ENFORCE_EQ(dst.numel(), src.numel(),
                 "Copy two tensors should have the same size");
   auto flag = core::ToMemcpyFlag(dst.device_type(), src.device_type());
   core::Memcpy(dst.mutableData<T>(), src.data<T>(), sizeof(T) * src.numel(),
                flag);
+#ifdef WITH_PERFTOOLS
+  profile_ctx.end_profile(name, src.device_type());
+#endif
 }
 
 }  // namespace core

--- a/turbo_transformers/layers/kernels/layer_norm.cpp
+++ b/turbo_transformers/layers/kernels/layer_norm.cpp
@@ -20,6 +20,9 @@
 #include "turbo_transformers/layers/kernels/common.h"
 #include "turbo_transformers/layers/kernels/gpu_layer_norm_kernel.h"
 #endif
+#ifdef WITH_PERFTOOLS
+#include "turbo_transformers/core/profiler.h"
+#endif
 
 namespace turbo_transformers {
 namespace layers {
@@ -28,7 +31,11 @@ static constexpr float g_epsilon = 1e-12;
 
 template <typename T>
 void LayerNorm(const core::Tensor& gamma, const core::Tensor& beta,
-               core::Tensor* out_tensor, T eps) {
+               core::Tensor* out_tensor, T eps, const std::string name) {
+#ifdef WITH_PERFTOOLS
+  auto& profile_ctx = core::Profiler::GetInstance();
+  profile_ctx.start_profile(name, out_tensor->device_type());
+#endif
   TT_ENFORCE_EQ(
       common::is_same_device_ctx(gamma.device_ctx(), beta.device_ctx()), true,
       "LayerNorm gamma and beta must be on the same device context.");
@@ -78,18 +85,26 @@ void LayerNorm(const core::Tensor& gamma, const core::Tensor& beta,
     TT_THROW("AddBiasLayerNorm device_type %d is not supported",
              out_tensor->device_type());
   }
+#ifdef WITH_PERFTOOLS
+  profile_ctx.end_profile(name, out_tensor->device_type());
+#endif
 }
 
 template void LayerNorm<float>(const core::Tensor& gamma,
                                const core::Tensor& beta,
-                               core::Tensor* out_tensor, float eps);
+                               core::Tensor* out_tensor, float eps,
+                               const std::string name);
 
 template <typename T>
 void AddBiasLayerNorm(const core::Tensor& input_tensor,
                       const core::Tensor& bias_tensor,
                       const core::Tensor& gamma_tensor,
                       const core::Tensor& beta_tensor, core::Tensor* out_tensor,
-                      T eps) {
+                      T eps, const std::string name) {
+#ifdef WITH_PERFTOOLS
+  auto& profile_ctx = core::Profiler::GetInstance();
+  profile_ctx.start_profile(name, input_tensor.device_type());
+#endif
   TT_ENFORCE_EQ(common::is_same_device_ctx(input_tensor.device_ctx(),
                                            bias_tensor.device_ctx()),
                 true,
@@ -151,13 +166,17 @@ void AddBiasLayerNorm(const core::Tensor& input_tensor,
     TT_THROW("LayerNorm device_type %d is not supported",
              input_tensor.device_type());
   }
+#ifdef WITH_PERFTOOLS
+  profile_ctx.end_profile(name, input_tensor.device_type());
+#endif
 }
 
 template void AddBiasLayerNorm<float>(const core::Tensor& input_tensor,
                                       const core::Tensor& bias_tensor,
                                       const core::Tensor& gamma_tensor,
                                       const core::Tensor& beta_tensor,
-                                      core::Tensor* out_tensor, float eps);
+                                      core::Tensor* out_tensor, float eps,
+                                      const std::string name);
 
 }  // namespace kernels
 }  // namespace layers

--- a/turbo_transformers/layers/kernels/layer_norm.h
+++ b/turbo_transformers/layers/kernels/layer_norm.h
@@ -22,14 +22,16 @@ namespace kernels {
 
 template <typename T>
 extern void LayerNorm(const core::Tensor& gamma, const core::Tensor& beta,
-                      core::Tensor* out_tensor, T eps = 1e-12);
+                      core::Tensor* out_tensor, T eps = 1e-12,
+                      const std::string name = "LayerNorm");
 
 template <typename T>
 extern void AddBiasLayerNorm(const core::Tensor& input_tensor,
                              const core::Tensor& bias_tensor,
                              const core::Tensor& gamma_tensor,
                              const core::Tensor& beta_tensor,
-                             core::Tensor* out_tensor, T eps = 1e-12);
+                             core::Tensor* out_tensor, T eps = 1e-12,
+                             const std::string name = "AddBiasLayerNorm");
 
 }  // namespace kernels
 }  // namespace layers

--- a/turbo_transformers/layers/kernels/mat_mul.h
+++ b/turbo_transformers/layers/kernels/mat_mul.h
@@ -17,10 +17,12 @@ namespace turbo_transformers {
 namespace layers {
 namespace kernels {
 extern void MatMul(const core::Tensor& A, bool a_trans, const core::Tensor& B,
-                   bool b_trans, float alpha, core::Tensor* out, float beta);
+                   bool b_trans, float alpha, core::Tensor* out, float beta,
+                   const std::string name = "MatMul");
 extern void BatchMatMul(const core::Tensor& A, bool a_trans,
                         const core::Tensor& B, bool b_trans, float alpha,
-                        core::Tensor* C, float beta);
+                        core::Tensor* C, float beta,
+                        const std::string name = "BatchMatMul");
 
 }  // namespace kernels
 }  // namespace layers

--- a/turbo_transformers/layers/kernels/softmax.cpp
+++ b/turbo_transformers/layers/kernels/softmax.cpp
@@ -81,7 +81,11 @@ void SoftmaxMask(float* qk_buf, const float* attr_mask, int64_t batch_size,
 }
 
 void ApplyMaskAndSoftmax(core::Tensor* inout, const core::Tensor& att_mask,
-                         float scale) {
+                         float scale, const std::string name) {
+#ifdef WITH_PERFTOOLS
+  auto& profile_ctx = core::Profiler::GetInstance();
+  profile_ctx.start_profile(name, inout->device_type());
+#endif
   auto batch_size = inout->shape(0);
   auto num_att_heads = inout->shape(1);
   auto from_seq_len = inout->shape(2);
@@ -115,6 +119,9 @@ void ApplyMaskAndSoftmax(core::Tensor* inout, const core::Tensor& att_mask,
   } else {
     TT_THROW("device_type is not supported");
   }
+#ifdef WITH_PERFTOOLS
+  profile_ctx.end_profile(name, inout->device_type());
+#endif
 }
 
 }  // namespace kernels

--- a/turbo_transformers/layers/kernels/softmax.h
+++ b/turbo_transformers/layers/kernels/softmax.h
@@ -20,7 +20,8 @@ namespace turbo_transformers {
 namespace layers {
 namespace kernels {
 extern void ApplyMaskAndSoftmax(core::Tensor* inout,
-                                const core::Tensor& att_mask, float scale);
+                                const core::Tensor& att_mask, float scale,
+                                const std::string name = "ApplyMaskAndSoftmax");
 
 }  // namespace kernels
 }  // namespace layers

--- a/turbo_transformers/layers/kernels/transpose.h
+++ b/turbo_transformers/layers/kernels/transpose.h
@@ -34,18 +34,20 @@ namespace kernels {
     output_tensor = tf.transpose(output_tensor, [0, 2, 1, 3])
     return output_tensor
  * **/
-extern void TransposeForScore(core::Tensor* output, const core::Tensor& input);
+extern void TransposeForScore(core::Tensor* output, const core::Tensor& input,
+                              const std::string name = "TransposeForScore");
 
-extern void AddBiasTransposeForScore(const core::Tensor& input,
-                                     const core::Tensor& bias,
-                                     core::Tensor* output);
+extern void AddBiasTransposeForScore(
+    const core::Tensor& input, const core::Tensor& bias, core::Tensor* output,
+    const std::string name = "AddBiasTransposeForScore");
 
 // input: (batch_size, seq_length, 3, head_num, *size_per_head)
 // bias: (3, head_num, size_per_head)
 // output: (3, batch_size, num_attention_heads, seq_length, size_per_head)
-extern void SplitAddBiasTransposeForScore(core::Tensor* output,
-                                          const core::Tensor& input_tensor,
-                                          const core::Tensor& bias_tensor);
+extern void SplitAddBiasTransposeForScore(
+    core::Tensor* output, const core::Tensor& input_tensor,
+    const core::Tensor& bias_tensor,
+    const std::string name = "SplitAddBiasTransposeForScore");
 
 }  // namespace kernels
 }  // namespace layers

--- a/turbo_transformers/layers/kernels/utils.h
+++ b/turbo_transformers/layers/kernels/utils.h
@@ -17,12 +17,14 @@ namespace turbo_transformers {
 namespace layers {
 namespace kernels {
 
-void AddBias(const core::Tensor& bias, core::Tensor* output);
+void AddBias(const core::Tensor& bias, core::Tensor* output,
+             const std::string name = "Concat");
 void AddInputBias(const core::Tensor& input1, const core::Tensor& input2,
-                  const core::Tensor& bias, core::Tensor* output);
+                  const core::Tensor& bias, core::Tensor* output,
+                  const std::string name = "Concat");
 template <typename T>
 void Concat(const core::Tensor& t1, const core::Tensor& t2, size_t dim,
-            core::Tensor* output);
+            core::Tensor* output, const std::string name = "Concat");
 
 }  // namespace kernels
 }  // namespace layers


### PR DESCRIPTION
Move profiler inside kernels.
Usage:
set CMakeList.txt
option(WITH_PROFILER "Compile with profiler" ON)
add ```with turbo_transformers.pref_guard("pref_test") as perf: ```above your python code.