### PR TITLE
Add a preliminary test script that demonstrates a quantized bert layer

### DIFF
--- a/turbo_transformers/layers/CMakeLists.txt
+++ b/turbo_transformers/layers/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(tt_layers OBJECT
         albert_layer.cpp
         multi_headed_attention.cpp
         positionwise_ffn.cpp
+        fused_ops.cpp
         )
 
 target_link_libraries(tt_layers PUBLIC tt_core tt_kernels)

--- a/turbo_transformers/layers/fused_ops.cpp
+++ b/turbo_transformers/layers/fused_ops.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 THL A29 Limited, a Tencent company.
+// All rights reserved.
+// Licensed under the BSD 3-Clause License (the "License"); you may
+// not use this file except in compliance with the License. You may
+// obtain a copy of the License at
+// https://opensource.org/licenses/BSD-3-Clause
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+// See the AUTHORS file for names of contributors.
+
+#include "turbo_transformers/layers/fused_ops.h"
+
+#include <loguru.hpp>
+
+#include "turbo_transformers/core/blas.h"
+#include "turbo_transformers/core/memory.h"
+#include "turbo_transformers/layers/kernels/activation.h"
+#include "turbo_transformers/layers/kernels/layer_norm.h"
+#include "turbo_transformers/layers/kernels/mat_mul.h"
+#include "turbo_transformers/layers/kernels/softmax.h"
+#include "turbo_transformers/layers/kernels/transpose.h"
+#ifdef WITH_PERFTOOLS
+#include "turbo_transformers/core/profiler.h"
+#endif
+
+namespace turbo_transformers {
+namespace layers {
+
+void FusedAddBiasGELU::operator()(core::Tensor* output_tensor) const {
+  kernels::AddBiasAct<float, kernels::ActivationType::Gelu>(
+      bias, output_tensor, "BertIntermediate/AddBiasAct");
+}
+
+}  // namespace layers
+}  // namespace turbo_transformers

--- a/turbo_transformers/layers/fused_ops.h
+++ b/turbo_transformers/layers/fused_ops.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 THL A29 Limited, a Tencent company.
+// All rights reserved.
+// Licensed under the BSD 3-Clause License (the "License"); you may
+// not use this file except in compliance with the License. You may
+// obtain a copy of the License at
+// https://opensource.org/licenses/BSD-3-Clause
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+// See the AUTHORS file for names of contributors.
+
+#pragma once
+#include <memory>
+#include <utility>
+#include "turbo_transformers/core/tensor.h"
+
+namespace turbo_transformers {
+namespace layers {
+
+class FusedAddBiasGELU {
+ public:
+  FusedAddBiasGELU(core::Tensor dense_bias)
+      : bias(std::move(dense_bias)) {}
+
+  void operator()(core::Tensor* output) const;
+
+ private:
+  core::Tensor bias;
+};
+
+}  // namespace layers
+}  // namespace turbo_transformers

--- a/turbo_transformers/python/pybind.cpp
+++ b/turbo_transformers/python/pybind.cpp
@@ -30,6 +30,7 @@
 #include "turbo_transformers/layers/positionwise_ffn.h"
 #include "turbo_transformers/layers/prepare_bert_masks.h"
 #include "turbo_transformers/layers/sequence_pool.h"
+#include "turbo_transformers/layers/fused_ops.h"
 
 namespace turbo_transformers {
 namespace python {
@@ -213,6 +214,12 @@ PYBIND11_MODULE(turbo_transformers_cxx, m) {
             std::move(layer_norm_weight), std::move(layer_norm_bias));
       }))
       .def("__call__", &layers::PositionwiseFeedForward::operator());
+
+  py::class_<layers::FusedAddBiasGELU>(m, "FusedAddBiasGELU")
+      .def(py::init([](core::Tensor &dense_bias) -> layers::FusedAddBiasGELU * {
+        return new layers::FusedAddBiasGELU(std::move(dense_bias));
+      }))
+      .def("__call__", &layers::FusedAddBiasGELU::operator());
 }
 
 }  // namespace python

--- a/turbo_transformers/python/tests/quantized_bert_intermediate.py
+++ b/turbo_transformers/python/tests/quantized_bert_intermediate.py
@@ -1,0 +1,43 @@
+import torch
+import transformers
+from  turbo_transformers.layers.utils import convert2tt_tensor, try_convert, convert_returns_as_type, ReturnType
+import os
+import sys
+
+class QBertIntermediate():
+    def __init__(self, dense, act):
+        self.qlinear = dense
+        self.act = act # Replace it with turbo API
+    def __call__(self, input_tensor):
+        if not isinstance(input_tensor, torch.Tensor):
+            input_tensor = convert_returns_as_type(input_tensor, ReturnType.TORCH)
+        return self.act(self.qlinear(input_tensor))
+    @staticmethod
+    def from_torch(intermediate):
+        return QBertIntermediate(intermediate.dense, intermediate.intermediate_act_fn)
+
+
+def print_size_of_model(model):
+    torch.save(model.state_dict(), "temp.p")
+    print('Size (MB):', os.path.getsize("temp.p")/1e6)
+    os.remove('temp.p')
+
+model = transformers.BertModel.from_pretrained('bert-base-uncased')
+model = torch.quantization.quantize_dynamic(model)
+model.eval()
+
+intermediate = model.encoder.layer[0].intermediate
+qintermediate = QBertIntermediate.from_torch(intermediate)
+# qlinear = intermediate.dense
+# print_size_of_model(qlinear)
+# packed_wb = qlinear._packed_params._packed_params
+# print("packed_wb (Byte) :", sys.getsizeof(packed_wb.storage()))
+# wb = torch.ops.quantized.linear_unpack(packed_wb)
+# print("unpacked w (Byte) :", sys.getsizeof(wb[0].storage()))
+
+input = torch.rand(10, 768)
+res = intermediate(input)
+res2 = qintermediate(input)
+# res2 = convert_returns_as_type(res2, ReturnType.TORCH)
+assert res.equal(res2)
+print("ok")

--- a/turbo_transformers/python/tests/quantized_bert_intermediate.py
+++ b/turbo_transformers/python/tests/quantized_bert_intermediate.py
@@ -1,43 +1,32 @@
 import torch
 import transformers
-from  turbo_transformers.layers.utils import convert2tt_tensor, try_convert, convert_returns_as_type, ReturnType
-import os
-import sys
-
-class QBertIntermediate():
-    def __init__(self, dense, act):
-        self.qlinear = dense
-        self.act = act # Replace it with turbo API
-    def __call__(self, input_tensor):
-        if not isinstance(input_tensor, torch.Tensor):
-            input_tensor = convert_returns_as_type(input_tensor, ReturnType.TORCH)
-        return self.act(self.qlinear(input_tensor))
-    @staticmethod
-    def from_torch(intermediate):
-        return QBertIntermediate(intermediate.dense, intermediate.intermediate_act_fn)
-
-
-def print_size_of_model(model):
-    torch.save(model.state_dict(), "temp.p")
-    print('Size (MB):', os.path.getsize("temp.p")/1e6)
-    os.remove('temp.p')
+import turbo_transformers
+from turbo_transformers.layers.utils import convert2tt_tensor, try_convert, convert_returns_as_type, ReturnType
+import time
 
 model = transformers.BertModel.from_pretrained('bert-base-uncased')
-model = torch.quantization.quantize_dynamic(model)
 model.eval()
+torch.set_grad_enabled(False)
 
-intermediate = model.encoder.layer[0].intermediate
-qintermediate = QBertIntermediate.from_torch(intermediate)
-# qlinear = intermediate.dense
-# print_size_of_model(qlinear)
-# packed_wb = qlinear._packed_params._packed_params
-# print("packed_wb (Byte) :", sys.getsizeof(packed_wb.storage()))
-# wb = torch.ops.quantized.linear_unpack(packed_wb)
-# print("unpacked w (Byte) :", sys.getsizeof(wb[0].storage()))
+intermediate = torch.quantization.quantize_dynamic(model.encoder.layer[0].intermediate)
+qintermediate = turbo_transformers.QBertIntermediate.from_torch(model.encoder.layer[0].intermediate)
+
 
 input = torch.rand(10, 768)
-res = intermediate(input)
-res2 = qintermediate(input)
-# res2 = convert_returns_as_type(res2, ReturnType.TORCH)
-assert res.equal(res2)
+loops = 10000
+
+
+start = time.time()
+for i in range(loops):
+    res = intermediate(input)
+end = time.time()
+print("torch layer IPS =", loops/(end-start))
+
+start = time.time()
+for i in range(loops):
+    res2 = qintermediate(input)
+end = time.time()
+print("our layer IPS =", loops/(end-start))
+
+assert torch.max(torch.abs(res-res2)) < 1e-3
 print("ok")

--- a/turbo_transformers/python/turbo_transformers/layers/__init__.py
+++ b/turbo_transformers/python/turbo_transformers/layers/__init__.py
@@ -12,7 +12,7 @@
 # See the AUTHORS file for names of contributors.
 
 from .modeling_bert import BertEmbeddings, BertIntermediate, BertOutput, BertAttention, BertLayer, SequencePool, \
-    BertEncoder, BertModel, PoolingType, BertPooler
+    BertEncoder, BertModel, PoolingType, BertPooler, QBertIntermediate
 
 from .modeling_albert import AlbertEmbeddings, AlbertAttention, AlbertLayer, AlbertTransformer, AlbertModel
 from .modeling_decoder import MultiHeadedAttention, PositionwiseFeedForward, TransformerDecoderLayer, TransformerDecoder
@@ -27,5 +27,5 @@ __all__ = [
     'PositionwiseFeedForward', 'AlbertLayer', 'AlbertEmbeddings',
     'AlbertAttention', 'AlbertTransformer', 'AlbertModel',
     'PositionwiseFeedForward', 'TransformerDecoderLayer', 'TransformerDecoder',
-    'RobertaModel'
+    'RobertaModel', 'QBertIntermediate'
 ]


### PR DESCRIPTION
Our goal is to integrate PyTorch's quantize_dynamic GEMM (Python) with turbo_transformers' non-linear opearators (C++) in order to provide fast inference. This script demonstrates a quantized BertImtermediate layer. Currently the C++ APIs such as `CPUAddBiasActKernel` has not been wrapped, so this script only implement the class framework rather than the real `QBertIntermediate`. 

Issue #103 