### PR TITLE
Fix gpu_benchmark & embedding kernel profile

### DIFF
--- a/benchmark/gpu_benchmark.py
+++ b/benchmark/gpu_benchmark.py
@@ -64,7 +64,6 @@ def benchmark_turbo_transformers(model_name: str, seq_len: int,
     else:
         raise (f"benchmark does not support {model_name}")
 
-    cfg = model.config  # type: transformers.BertConfig
     input_ids = torch.randint(low=0,
                               high=cfg.vocab_size - 1,
                               size=(batch_size, seq_len),

--- a/turbo_transformers/layers/kernels/embedding.cpp
+++ b/turbo_transformers/layers/kernels/embedding.cpp
@@ -32,7 +32,7 @@ void LookupEmbedding(core::Tensor *out_tensor,
                      const std::string name) {
 #ifdef WITH_PERFTOOLS
   auto &profile_ctx = core::Profiler::GetInstance();
-  profile_ctx.start_profile(name, bias_tensor.device_type());
+  profile_ctx.start_profile(name, ids_tensor.device_type());
 #endif
   TT_ENFORCE_EQ(common::is_same_device_ctx(
                     out_tensor->device_ctx(), embedding_table.device_ctx()),
@@ -80,7 +80,7 @@ void LookupEmbedding(core::Tensor *out_tensor,
     TT_THROW("device_type is not supported");
   }
 #ifdef WITH_PERFTOOLS
-  profile_ctx.end_profile(name, bias_tensor.device_type());
+  profile_ctx.end_profile(name, ids_tensor.device_type());
 #endif
 }
 


### PR DESCRIPTION
This PR fix 2 tiny bugs.

### 1. gpu_benchmark.py
![image](https://user-images.githubusercontent.com/4970790/87941861-55379080-cace-11ea-9c7b-8d2ea5002bee.png)

When running `gpu_benchmark.py`, it complained that `attribute config` was missing. We can just remove it.

### 2. kernels/embedding.cpp
![image](https://user-images.githubusercontent.com/4970790/87942029-962fa500-cace-11ea-853f-51803dd84d23.png)

When compiling the project with `option(WITH_PROFILER  "Compile with profiler"   ON)`, above code lead to compilation failure.