### PR TITLE
Allocator test

### DIFF
--- a/example/cpp/bert_model.cpp
+++ b/example/cpp/bert_model.cpp
@@ -186,13 +186,13 @@ struct BertModel::Impl {
     if (poistion_ids.size() != 0) {
       TT_ENFORCE_EQ(
           poistion_ids.size(), static_cast<size_t>(batch_size),
-          "Position ids should have the same batch size as ibout ids");
+          "Position ids should have the same batch size as input ids");
       PadTensor(poistion_ids, batch_size, max_seq_len, static_cast<int64_t>(0),
                 device_type_, &positionIds);
     }
     if (segment_ids.size() != 0) {
       TT_ENFORCE_EQ(segment_ids.size(), static_cast<size_t>(batch_size),
-                    "Segment ids should have the same batch size as ibout ids");
+                    "Segment ids should have the same batch size as input ids");
       PadTensor(segment_ids, batch_size, max_seq_len, static_cast<int64_t>(0),
                 device_type_, &seqType);
     }

--- a/turbo_transformers/core/tensor.cpp
+++ b/turbo_transformers/core/tensor.cpp
@@ -29,7 +29,7 @@ static void DLManagedTensorDeletor(DLManagedTensor *self) {
         self->dl_tensor.ctx.device_type == kDLGPU) {
       // free(self->dl_tensor.data);
       Allocator &allocator = Allocator::GetInstance();
-      allocator.free(self->dl_tensor.data, "cub",
+      allocator.free(self->dl_tensor.data, "bestfit",
                      self->dl_tensor.ctx.device_type);
     }
   }
@@ -63,7 +63,7 @@ DLManagedTensor *NewDLPackTensor(const std::vector<int64_t> &shape_list,
   if (device == kDLCPU || device == kDLGPU) {
     size_t size = numel * (bits / 8);
     Allocator &allocator = Allocator::GetInstance();
-    newTensor->dl_tensor.data = allocator.allocate(size, "cub", device);
+    newTensor->dl_tensor.data = allocator.allocate(size, "bestfit11", device);
   } else {
     TT_THROW("only cpu and gpu are supported!");
   }

--- a/turbo_transformers/layers/bert_embedding.cpp
+++ b/turbo_transformers/layers/bert_embedding.cpp
@@ -17,10 +17,6 @@
 #include "turbo_transformers/layers/kernels/common.h"
 #include "turbo_transformers/layers/kernels/layer_norm.h"
 #include "turbo_transformers/layers/kernels/embedding.h"
-#ifdef TT_WITH_CUDA
-#include "turbo_transformers/core/cuda_device_context.h"
-#include "turbo_transformers/layers/kernels/gpu_embedding_kernel.h"
-#endif
 
 namespace turbo_transformers {
 namespace layers {

--- a/turbo_transformers/layers/bert_intermediate.cpp
+++ b/turbo_transformers/layers/bert_intermediate.cpp
@@ -53,7 +53,7 @@ void BertIntermediate::EnforceShapeAndType() const {
   TT_ENFORCE_EQ(dense_weight_.n_dim(), 2, "dense weight must be matrix");
   TT_ENFORCE_EQ(dense_bias_.n_dim(), 1, "dense bias must be vector");
   TT_ENFORCE_EQ(dense_weight_.shape(1), dense_bias_.shape(0),
-                "weight and bias shape mismatch %d, %d", dense_weight_.shape(0),
+                "weight and bias shape mismatch %d, %d", dense_weight_.shape(1),
                 dense_bias_.shape(0));
 
   if (loguru::current_verbosity_cutoff() >= 3) {

--- a/turbo_transformers/layers/kernels/transpose.cpp
+++ b/turbo_transformers/layers/kernels/transpose.cpp
@@ -83,6 +83,10 @@ void TransposeForScore(core::Tensor* output, const core::Tensor& input,
   auto& profile_ctx = core::Profiler::GetInstance();
   profile_ctx.start_profile(name, input.device_type());
 #endif
+  TT_ENFORCE_EQ(input.n_dim(), 4, "input should be a 4-D tensor");
+  TT_ENFORCE_GE(output->n_dim(), 3, "output tensor dim should be greater than 3");
+  TT_ENFORCE_EQ(input.numel(), output->numel(),
+                "input.numel() and output.numel() should be the same");
   if (input.device_type() == kDLCPU && output->device_type() == kDLCPU) {
     TransposeForScoreImpl(output->mutableData<float>(), input.data<float>(),
                           output->shape(0), output->shape(1), input.shape(1),


### PR DESCRIPTION
除了rebase master分支代码外，仅修改tensor.cpp中内存分配的策略，并且allocate参数故意设置错误策略"bestfit11".