### PR TITLE
Fix/bert example bug

### DIFF
--- a/example/python/bert_for_sequence_classification_example.py
+++ b/example/python/bert_for_sequence_classification_example.py
@@ -105,4 +105,6 @@ torch_model = TorchBertForSequenceClassification.from_pretrained(model_id)
 # torch_result holds the returned logits from original Transformers model
 torch_result = torch_model(**inputs)[0]
 print(turbo_result)
+# tensor([[0.2716, 0.0318]], grad_fn=<AddmmBackward>)
 print(torch_result) # torch_result and turbo_result should hold the same logits
+# tensor([[0.2716, 0.0318]], grad_fn=<AddmmBackward>)


### PR DESCRIPTION
Fixed bert_for_sequence_classification.py bug to return logits properly using Bert's pooled output.
Used huggingface/transformers tokenizer's encode_plus function to encode text (which provides attention_mask as well).
Tested to ensure it was working using thufeifeibear/turbo_transformers_cpu:latest image.