### PR TITLE
The memory of addspilttranspose is not continous for Q, K, V out.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_C_FLAGS "-Wall")
 
-set(TURBO_TRANSFORMERS_VERSION 0.4.1)
+set(TURBO_TRANSFORMERS_VERSION 0.4.2)
 
 option(WITH_PROFILER  "Compile with profiler"   OFF)
 option(WITH_GPU       "Build with GPU"          OFF)

--- a/benchmark/run_gpu_fixed_benchmark.sh
+++ b/benchmark/run_gpu_fixed_benchmark.sh
@@ -29,7 +29,7 @@ do
     for framework in ${FRAMEWORKS[*]}
     do
       python benchmark.py ${MODEL} --seq_len=${seq_len} --batch_size=${batch_size}\
-          -n ${N} --framework=${framework}
+          -n ${N} --framework=${framework} --use_gpu
     done
   done
 done

--- a/turbo_transformers/layers/bert_intermediate.cpp
+++ b/turbo_transformers/layers/bert_intermediate.cpp
@@ -45,7 +45,7 @@ void BertIntermediate::operator()(const core::Tensor& input_tensor,
   kernels::AddBiasAct<float, kernels::ActivationType::Gelu>(
       dense_bias_, output_tensor, "BertIntermediate/AddBiasAct");
 #ifdef WITH_PERFTOOLS
-  profile_ctx.end_profile("BertIntermediate");
+  profile_ctx.end_profile("BertIntermediate", input_tensor.device_type());
 #endif
 }
 

--- a/turbo_transformers/layers/bert_output.cpp
+++ b/turbo_transformers/layers/bert_output.cpp
@@ -48,7 +48,7 @@ void BertOutput::operator()(const core::Tensor &hidden_states,
       input_tensor, dense_bias_, layer_norm_weight_, layer_norm_bias_,
       output_tensor, 1e-12, "BertOutput/AddBiasLayerNorm");
 #ifdef WITH_PERFTOOLS
-  profile_ctx.end_profile("BertOutput");
+  profile_ctx.end_profile("BertOutput", input_tensor.device_type());
 #endif
 }
 

--- a/turbo_transformers/layers/kernels/gpu_transpose_kernel.h
+++ b/turbo_transformers/layers/kernels/gpu_transpose_kernel.h
@@ -25,6 +25,13 @@ void GPUSplitAddBiasTransposeForScore(const T* input_data, const T* bias_data,
                                       int64_t size_per_head,
                                       cudaStream_t stream);
 
+template <typename T>
+void GPUSplitAddBiasTransposeForScoreThreeOutput(
+    const T* input_data, const T* bias_data, int64_t batch_size,
+    int64_t seq_len, int64_t weight_num, int64_t num_attention_heads,
+    int64_t size_per_head, cudaStream_t stream, T* q_out_data, T* k_out_data,
+    T* v_out_data);
+
 template <typename T, bool AddBias>
 void GPUTransposeForScore(const T* input_data, const T* bias,
                           int64_t batch_size, int64_t seq_len,

--- a/turbo_transformers/layers/kernels/transpose.cpp
+++ b/turbo_transformers/layers/kernels/transpose.cpp
@@ -84,7 +84,8 @@ void TransposeForScore(core::Tensor* output, const core::Tensor& input,
   profile_ctx.start_profile(name, input.device_type());
 #endif
   TT_ENFORCE_EQ(input.n_dim(), 4, "input should be a 4-D tensor");
-  TT_ENFORCE_GE(output->n_dim(), 3, "output tensor dim should be greater than 3");
+  TT_ENFORCE_GE(output->n_dim(), 3,
+                "output tensor dim should be greater than 3");
   TT_ENFORCE_EQ(input.numel(), output->numel(),
                 "input.numel() and output.numel() should be the same");
   if (input.device_type() == kDLCPU && output->device_type() == kDLCPU) {
@@ -158,9 +159,6 @@ void SplitAddBiasTransposeForScore(core::Tensor* output_tensor,
   TT_ENFORCE_EQ(output_tensor->n_dim(), 5,
                 "output_tensor should be (weight_num, batch_size, seq_length, "
                 "num_attention_heads, size_per_head)");
-  // TT_ENFORCE_EQ(bias_tensor.n_dim(), 1,
-  //               "output_tensor should be (weight_num * num_attention_heads, "
-  //               "size_per_head)");
 
   auto batch_size = output_tensor->shape(1);
   auto seq_length = output_tensor->shape(3);
@@ -219,6 +217,105 @@ void SplitAddBiasTransposeForScore(core::Tensor* output_tensor,
     GPUSplitAddBiasTransposeForScore<float>(
         input, bias, output, batch_size, seq_length, weight_num,
         num_attention_heads, width, cuda_ctx.stream());
+#endif
+  } else {
+    TT_THROW("device_type is not supported");
+  }
+#ifdef WITH_PERFTOOLS
+  profile_ctx.end_profile(name, input_tensor.device_type());
+#endif
+}
+
+// input_tensor: 4D array (batch_size, seq_length, 3, head_num * size_per_head)
+void SplitAddBiasTransposeForScore(const core::Tensor& input_tensor,
+                                   const core::Tensor& bias_tensor,
+                                   core::Tensor& q_out_tensor,
+                                   core::Tensor& k_out_tensor,
+                                   core::Tensor& v_out_tensor,
+                                   const std::string name) {
+#ifdef WITH_PERFTOOLS
+  auto& profile_ctx = core::Profiler::GetInstance();
+  profile_ctx.start_profile(name, input_tensor.device_type());
+#endif
+
+  TT_ENFORCE_EQ(input_tensor.n_dim(), 4,
+                "output_tensor should be (batch_size, seq_length, "
+                "num_attention_heads * size_per_head)");
+
+  auto batch_size = input_tensor.shape(0);
+  auto seq_length = input_tensor.shape(1);
+  auto weight_num = 3;
+  auto num_attention_heads = q_out_tensor.shape(1);
+  auto width = input_tensor.shape(3) / num_attention_heads;
+  auto input = input_tensor.data<float>();
+  auto bias = bias_tensor.data<float>();
+  auto q_out = q_out_tensor.mutableData<float>();
+  auto k_out = k_out_tensor.mutableData<float>();
+  auto v_out = v_out_tensor.mutableData<float>();
+
+  TT_ENFORCE_EQ(common::is_same_device_ctx(input_tensor.device_ctx(),
+                                           bias_tensor.device_ctx()),
+                true,
+                "SplitAddBiasTransposeForScore: input_tensor and bias_tensor "
+                "should have the same device type and device id.");
+  TT_ENFORCE_EQ(common::is_same_device_ctx(input_tensor.device_ctx(),
+                                           q_out_tensor.device_ctx()),
+                true,
+                "SplitAddBiasTransposeForScore: input_tensor and q_out_tensor "
+                "should have the same device type and device id.");
+
+  if (q_out_tensor.device_type() == kDLCPU &&
+      input_tensor.device_type() == kDLCPU &&
+      bias_tensor.device_type() == kDLCPU) {
+#pragma omp parallel for
+    for (int64_t idx = 0; idx < batch_size * weight_num * seq_length; ++idx) {
+      auto batch_idx = idx / (seq_length * weight_num);
+      auto seq_idx = idx / weight_num % seq_length;
+      auto weight_idx = idx % weight_num;
+
+      for (int64_t head_idx = 0; head_idx < num_attention_heads; ++head_idx) {
+        auto* src_ptr =
+            input +
+            batch_idx *
+                (seq_length * weight_num * num_attention_heads * width) +
+            seq_idx * weight_num * num_attention_heads * width +
+            weight_idx * (num_attention_heads * width) + head_idx * width;
+        float* dst_ptr = nullptr;
+        switch (weight_idx) {
+          case 0:
+            dst_ptr = q_out +
+                      batch_idx * (num_attention_heads * seq_length * width) +
+                      head_idx * seq_length * width + seq_idx * width;
+            break;
+          case 1:
+            dst_ptr = k_out +
+                      batch_idx * (num_attention_heads * seq_length * width) +
+                      head_idx * seq_length * width + seq_idx * width;
+            break;
+          case 2:
+            dst_ptr = v_out +
+                      batch_idx * (num_attention_heads * seq_length * width) +
+                      head_idx * seq_length * width + seq_idx * width;
+            break;
+          default:
+            break;
+        }
+        auto* bias_ptr =
+            bias + weight_idx * width * num_attention_heads + head_idx * width;
+#pragma omp simd
+        for (int64_t width_idx = 0; width_idx < width; ++width_idx) {
+          dst_ptr[width_idx] = src_ptr[width_idx] + bias_ptr[width_idx];
+        }
+      }
+    }  // end for
+  } else if (q_out_tensor.device_type() == kDLGPU &&
+             input_tensor.device_type() == kDLGPU &&
+             bias_tensor.device_type() == kDLGPU) {
+#ifdef TT_WITH_CUDA
+    core::CUDADeviceContext& cuda_ctx = core::CUDADeviceContext::GetInstance();
+    GPUSplitAddBiasTransposeForScoreThreeOutput<float>(
+        input, bias, batch_size, seq_length, weight_num, num_attention_heads,
+        width, cuda_ctx.stream(), q_out, k_out, v_out);
 #endif
   } else {
     TT_THROW("device_type is not supported");

--- a/turbo_transformers/layers/kernels/transpose.cpp
+++ b/turbo_transformers/layers/kernels/transpose.cpp
@@ -263,7 +263,12 @@ void SplitAddBiasTransposeForScore(const core::Tensor& input_tensor,
                 true,
                 "SplitAddBiasTransposeForScore: input_tensor and q_out_tensor "
                 "should have the same device type and device id.");
-
+  TT_ENFORCE_EQ(q_out_tensor.numel(), input_tensor.numel() / 3,
+                "numel of q_out_tensor should 1/3 of input tensor");
+  TT_ENFORCE_EQ(k_out_tensor.numel(), input_tensor.numel() / 3,
+                "numel of q_out_tensor should 1/3 of input tensor");
+  TT_ENFORCE_EQ(v_out_tensor.numel(), input_tensor.numel() / 3,
+                "numel of q_out_tensor should 1/3 of input tensor");
   if (q_out_tensor.device_type() == kDLCPU &&
       input_tensor.device_type() == kDLCPU &&
       bias_tensor.device_type() == kDLCPU) {

--- a/turbo_transformers/layers/kernels/transpose.h
+++ b/turbo_transformers/layers/kernels/transpose.h
@@ -44,9 +44,18 @@ extern void AddBiasTransposeForScore(
 // input: (batch_size, seq_length, 3, head_num, *size_per_head)
 // bias: (3, head_num, size_per_head)
 // output: (3, batch_size, num_attention_heads, seq_length, size_per_head)
+// TODO(jiaruifang) the output is a tensor contains a continous memory space,
+// which stores q_out, k_out, v_out. Because the lifetime of q_out, k_out and
+// v_out are different, we should seperate them into 3 memory space
 extern void SplitAddBiasTransposeForScore(
     core::Tensor* output, const core::Tensor& input_tensor,
     const core::Tensor& bias_tensor,
+    const std::string name = "SplitAddBiasTransposeForScore");
+
+// A API friendly to variable-length input memory allocations.
+extern void SplitAddBiasTransposeForScore(
+    const core::Tensor& input_tensor, const core::Tensor& bias_tensor,
+    core::Tensor& q_out, core::Tensor& k_out, core::Tensor& v_out,
     const std::string name = "SplitAddBiasTransposeForScore");
 
 }  // namespace kernels

--- a/turbo_transformers/layers/multi_headed_attention.cpp
+++ b/turbo_transformers/layers/multi_headed_attention.cpp
@@ -77,7 +77,7 @@ void MultiHeadedAttention::operator()(
   auto devtype = query_tensor.device_type();
   auto devid = query_tensor.device_id();
 
-  // TODO we should caching allocate intermediate tensor.
+  // TODO we should caching allocated intermediate tensor.
   core::Tensor *q_ptr{nullptr}, *k_ptr{nullptr}, *v_ptr{nullptr};
   core::Tensor q_out{nullptr}, k_out{nullptr}, v_out{nullptr};
   core::Tensor q_out1(nullptr);
@@ -87,7 +87,6 @@ void MultiHeadedAttention::operator()(
   core::Tensor v_out2(nullptr);
   core::Tensor k_out2(nullptr);
   core::Tensor qkv_out1(nullptr);
-  core::Tensor qkv_out2(nullptr);
 
   bool layer_cache_not_none = layer_cache.size() > 0 ? true : false;
   bool memory_keys_not_none = false, memory_values_not_none = false,
@@ -218,13 +217,13 @@ void MultiHeadedAttention::operator()(
     }
     q_out.Reshape<float>(
         {batch_size, num_attention_heads_, query_seq_length, size_per_head},
-        devtype, devid, "q/Reshape");
+        devtype, devid, "self/q/Reshape");
     k_out.Reshape<float>(
         {batch_size, num_attention_heads_, query_seq_length, size_per_head},
-        devtype, devid, "k/Reshape");
+        devtype, devid, "self/k/Reshape");
     v_out.Reshape<float>(
         {batch_size, num_attention_heads_, query_seq_length, size_per_head},
-        devtype, devid, "v/Reshape");
+        devtype, devid, "self/v/Reshape");
 
     kernels::SplitAddBiasTransposeForScore(
         qkv_out1, qkv_bias_, q_out, k_out, v_out,


### PR DESCRIPTION
The output of SplitAddBiasTransposeForScore is three independent tensors, rather than 3 tensors in continuous memory space.
The PR also Fixed the memory leak bug.
fix two profiler bugs of BERT.